### PR TITLE
[FIX] stock_move_backdating: user timezone date and date on stock valuation

### DIFF
--- a/stock_move_backdating/models/stock_move.py
+++ b/stock_move_backdating/models/stock_move.py
@@ -5,7 +5,7 @@
 # Copyright 2023 Simone Rubino - TAKOBI
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import fields, models
 from odoo.fields import first
 
 from .stock_move_line import check_date
@@ -27,9 +27,28 @@ class StockMove(models.Model):
             )
             move_account_moves.update(
                 {
-                    "date": stock_move.date.date(),
+                    "date": fields.Date.context_today(self, stock_move.date),
                 }
             )
+
+    def _backdating_stock_valuation_layers(self):
+        """Set date on linked stock.valuation.layer same for each move in `self`."""
+        picking_stock_valuation_layers = self.env["stock.valuation.layer"].search(
+            [
+                ("stock_move_id", "in", self.ids),
+            ],
+        )
+        for stock_move in self:
+            stock_valuation_layers = picking_stock_valuation_layers.filtered(
+                lambda svl: svl.stock_move_id == stock_move
+            )
+            for svl in stock_valuation_layers:
+                self._cr.execute(
+                    """
+                    update stock_valuation_layer set create_date = %s where id = %s
+                """,
+                    (stock_move.date, svl.id),
+                )
 
     def _backdating_action_done(self, moves_todo, cancel_backorder=False):
         """Process the moves one by one, backdating the ones that need to."""

--- a/stock_move_backdating/models/stock_move.py
+++ b/stock_move_backdating/models/stock_move.py
@@ -33,6 +33,7 @@ class StockMove(models.Model):
 
     def _backdating_stock_valuation_layers(self):
         """Set date on linked stock.valuation.layer same for each move in `self`."""
+        self = self.sudo()
         picking_stock_valuation_layers = self.env["stock.valuation.layer"].search(
             [
                 ("stock_move_id", "in", self.ids),

--- a/stock_move_backdating/models/stock_picking.py
+++ b/stock_move_backdating/models/stock_picking.py
@@ -45,9 +45,17 @@ class StockPicking(models.Model):
         stock_moves._backdating_account_moves()
         return True
 
+    def _backdating_update_stock_valuation_layers_date(self):
+        """Set date on linked stock.valuation.layer same as date on stock.move."""
+        self.ensure_one()
+        stock_moves = self.move_lines
+        stock_moves._backdating_stock_valuation_layers()
+        return True
+
     def _action_done(self):
         result = super()._action_done()
         for picking in self:
             picking._backdating_update_picking_date()
             picking._backdating_update_account_moves_date()
+            picking._backdating_update_stock_valuation_layers_date()
         return result

--- a/stock_move_backdating/models/stock_quant.py
+++ b/stock_move_backdating/models/stock_quant.py
@@ -52,7 +52,7 @@ class StockQuant(models.Model):
             if date_backdating:
                 inventory_ctx = inventory.with_context(
                     date_backdating=date_backdating,
-                    force_period_date=date_backdating.date(),
+                    force_period_date=fields.Date.context_today(self, date_backdating),
                 )
                 super(StockQuant, inventory_ctx)._apply_inventory()
                 inventory.date_backdating = False


### PR DESCRIPTION
**FIX**
- Change datetime.date() to fields.Date.context_today(self, datetime)
- Set date on linked stock.valuation.layer same stock.move

@ps-tubtim @Nantikan23 Could you review this please ?